### PR TITLE
feat: add postinstall auto-configuration for .mcp.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+src/
+tsconfig.json
+.env
+.env.example
+*.md
+.git/
+.gitignore
+node_modules/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,31 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 Replace `your-email@example.com` and `your-password` with your TGO Yemek credentials.
 
+## Local Installation (Claude Code)
+
+For project-specific installation with Claude Code:
+
+```bash
+npm install food402
+```
+
+This automatically adds `food402` to your `.mcp.json`. Open the file and update your credentials:
+
+```json
+{
+  "mcpServers": {
+    "food402": {
+      "command": "node",
+      "args": ["./node_modules/food402/dist/index.js"],
+      "env": {
+        "TGO_EMAIL": "your-email@example.com",
+        "TGO_PASSWORD": "your-password"
+      }
+    }
+  }
+}
+```
+
 ## Prerequisites
 
 ### Account Setup Required

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "food402",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MCP server for ordering food from TGO Yemek",
   "type": "module",
   "bin": {
@@ -12,6 +12,7 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "build": "tsc",
+    "postinstall": "node dist/postinstall.js",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+// Find project root (where npm install was run)
+const projectRoot = process.env.INIT_CWD || process.cwd();
+const mcpJsonPath = join(projectRoot, '.mcp.json');
+
+const food402Config = {
+  command: "node",
+  args: ["./node_modules/food402/dist/index.js"],
+  env: {
+    TGO_EMAIL: "your-email@example.com",
+    TGO_PASSWORD: "your-password"
+  }
+};
+
+let config: { mcpServers: Record<string, unknown> } = { mcpServers: {} };
+
+if (existsSync(mcpJsonPath)) {
+  try {
+    config = JSON.parse(readFileSync(mcpJsonPath, 'utf-8'));
+    if (!config.mcpServers) config.mcpServers = {};
+  } catch {
+    // Invalid JSON, start fresh
+  }
+}
+
+config.mcpServers.food402 = food402Config;
+
+writeFileSync(mcpJsonPath, JSON.stringify(config, null, 2) + '\n');
+console.log('✓ Added food402 to .mcp.json');
+console.log('→ Update TGO_EMAIL and TGO_PASSWORD in .mcp.json with your credentials');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "node16",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
     "strict": true,
     "outDir": "./dist",


### PR DESCRIPTION
Automatically configures MCP server in local .mcp.json when users run npm install food402. Updates README with local installation guide.